### PR TITLE
Current page is not added to link provider dropdown

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1,5 +1,10 @@
 var widgetId = Fliplet.Widget.getDefaultId();
 var data = Fliplet.Widget.getData() || {};
+var page = Fliplet.Widget.getPage();
+var omitPages = page ? [page.id] : [];
+
+data.action = data.action || {};
+data.action.omitPages = omitPages;
 
 var linkActionProvider = Fliplet.Widget.open('com.fliplet.link', {
   // If provided, the iframe will be appended here,


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#4498

## Description
Added omit page property. I was not able to test this because inline-link component is called from studio, but if Fliplet.Widget.getPage() is available it should work)

## Backward compatibility
This change is fully backward compatible.